### PR TITLE
Add ability to go back to previous screens

### DIFF
--- a/app/app/src/main/java/app/emmabritton/cibusana/AppActivity.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/AppActivity.kt
@@ -2,6 +2,7 @@ package app.emmabritton.cibusana
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -22,6 +23,14 @@ class AppActivity : ComponentActivity() {
 
         val uiState = MutableStateFlow(AppState.init())
         val runtime = Runtime { uiState.value = it }
+
+        onBackPressedDispatcher.addCallback(this, object: OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (!runtime.goBack()) {
+                    finish()
+                }
+            }
+        })
 
         setContent {
             CibusanaTheme {

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/Actions.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/Actions.kt
@@ -11,3 +11,8 @@ class UnknownAction(msg: String) :
 class UnknownUiState(private val name: String) : Action {
     fun toEffect() = AppEffect(AppState.init().copy(error = "Unknown UI state: $name"), emptyList())
 }
+
+class GoToState(private val appState: AppState, private val state: UiState) : Action {
+    fun toEffect() = AppEffect(appState.copy(uiState = state), emptyList())
+    override fun describe() ="GoToState(${state.javaClass.simpleName})"
+}

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/AppRuntime.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/AppRuntime.kt
@@ -3,6 +3,7 @@ package app.emmabritton.cibusana.system
 import android.os.Handler
 import android.os.Looper
 import app.emmabritton.system.*
+import timber.log.Timber
 
 typealias AppEffect = Effect<AppState>
 
@@ -25,5 +26,21 @@ class Runtime(
     render,
     commandHandler,
     AppState.init()
-)
+) {
+    override fun receive(action: Action) {
+        Timber.tag(TAG).d("Received ${action.describe()} during $state")
+        super.receive(action)
+    }
+
+    fun goBack(): Boolean {
+        return state.uiState.previousState?.let {
+            receive(GoToState(state, it))
+            true
+        } ?: false
+    }
+
+    companion object {
+        private const val TAG = "[RT]"
+    }
+}
 

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/AppRuntime.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/AppRuntime.kt
@@ -32,11 +32,19 @@ class Runtime(
         super.receive(action)
     }
 
+    /**
+     * Returns true if runtime has handled back pressed
+     */
     fun goBack(): Boolean {
-        return state.uiState.previousState?.let {
-            receive(GoToState(state, it))
-            true
-        } ?: false
+        synchronized(stateChangeLock) {
+            val previousState = state.uiState.previousState
+            val isFirstScreen = state.uiState.isFirstScreen
+
+            return if (previousState != null) {
+                receive(GoToState(state, previousState))
+                true
+            } else !isFirstScreen
+        }
     }
 
     companion object {

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/AppState.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/AppState.kt
@@ -7,6 +7,14 @@ data class AppState(
     val error: String?,
     val uiState: UiState,
 ) : State {
+    override fun toString(): String {
+        return if (error != null) {
+            "Error: $error"
+        } else {
+            uiState.javaClass.simpleName
+        }
+    }
+
     companion object {
         fun init(): AppState {
             return AppState(null, WelcomeState)
@@ -14,5 +22,16 @@ data class AppState(
     }
 }
 
-interface UiState
+
+open class UiState(
+    /**
+     * When back is pressed the ui state should be reset to this
+     */
+    val previousState: UiState?,
+    /**
+     * When back is pressed and previousState is null
+     * and isFirstScreen is true, then close app
+     */
+    val isFirstScreen: Boolean
+)
 

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/Reducer.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/Reducer.kt
@@ -15,6 +15,7 @@ fun reduce(action: Action, state: AppState): AppEffect {
         is LoginAction -> reduceLoginAction(action, state)
         is WelcomeAction -> reduceWelcomeAction(action, state)
         is RegisterAction -> reduceRegisterAction(action, state)
+        is GoToState -> action.toEffect()
         is CommandException -> {
             Timber.e(action.cause, action.name)
             AppEffect(

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/ThreadedCommandHandler.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/ThreadedCommandHandler.kt
@@ -4,6 +4,7 @@ import app.emmabritton.system.ActionReceiver
 import app.emmabritton.system.Command
 import app.emmabritton.system.CommandException
 import app.emmabritton.system.CommandHandler
+import timber.log.Timber
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
@@ -15,12 +16,18 @@ class ThreadedCommandHandler : CommandHandler {
     override lateinit var actionReceiver: ActionReceiver
 
     override fun add(command: Command) {
+        Timber.tag(TAG).d("Queuing ${command.javaClass.simpleName}")
         executor.submit {
             try {
+                Timber.tag(TAG).d("Executing ${command.javaClass.simpleName}")
                 command.run(actionReceiver)
             } catch (e: Exception) {
                 actionReceiver.receive(CommandException(command.javaClass.simpleName, e))
             }
         }
+    }
+
+    companion object {
+        private const val TAG = "[CH]"
     }
 }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/login/Reducer.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/login/Reducer.kt
@@ -47,7 +47,7 @@ fun reduceLoginAction(action: LoginAction, state: AppState): AppEffect {
             emptyList()
         )
         is LoginAction.Accepted -> AppEffect(
-            state.copy(uiState = LoginState.LoggedIn(action.name, action.token, (state.uiState as LoginState.Loading).details)),
+            state.copy(uiState = LoginState.LoggedIn(action.name, action.token)),
             emptyList()
         )
     }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/login/Reducer.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/login/Reducer.kt
@@ -3,6 +3,7 @@ package app.emmabritton.cibusana.system.login
 import app.emmabritton.cibusana.system.AppEffect
 import app.emmabritton.cibusana.system.AppState
 import app.emmabritton.cibusana.system.InvalidState
+import app.emmabritton.cibusana.system.register.RegisterState
 
 fun reduceLoginAction(action: LoginAction, state: AppState): AppEffect {
     if (state.uiState !is LoginState) {
@@ -46,7 +47,7 @@ fun reduceLoginAction(action: LoginAction, state: AppState): AppEffect {
             emptyList()
         )
         is LoginAction.Accepted -> AppEffect(
-            state.copy(uiState = LoginState.LoggedIn(action.name, action.token)),
+            state.copy(uiState = LoginState.LoggedIn(action.name, action.token, (state.uiState as LoginState.Loading).details)),
             emptyList()
         )
     }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/login/State.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/login/State.kt
@@ -2,23 +2,23 @@ package app.emmabritton.cibusana.system.login
 
 import app.emmabritton.cibusana.system.UiState
 
-sealed class LoginState: UiState {
-    data class Entering(val email: String, val password: String): LoginState() {
+sealed class LoginState(previousState: UiState?) : UiState(previousState, false) {
+    data class Entering(val email: String, val password: String,private val lastScreen: UiState?): LoginState(lastScreen) {
         fun toLoading() = Loading(this)
         companion object {
-            fun init(): Entering {
-                return Entering("", "")
+            fun init(previousState: UiState?): Entering {
+                return Entering("", "", previousState)
             }
         }
     }
 
-    data class Loading(val details: Entering): LoginState() {
+    data class Loading(val details: Entering): LoginState(null) {
         fun toError(msg: String) = Error(msg, details)
     }
 
-    data class Error(val message: String, val details: Entering): LoginState() {
+    data class Error(val message: String, val details: Entering): LoginState(details) {
         fun toEntering() = details
     }
 
-    data class LoggedIn(val name: String, val token: String): LoginState()
+    data class LoggedIn(val name: String, val token: String, private val lastScreen: UiState?): LoginState(lastScreen)
 }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/login/State.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/login/State.kt
@@ -2,8 +2,8 @@ package app.emmabritton.cibusana.system.login
 
 import app.emmabritton.cibusana.system.UiState
 
-sealed class LoginState(previousState: UiState?) : UiState(previousState, false) {
-    data class Entering(val email: String, val password: String,private val lastScreen: UiState?): LoginState(lastScreen) {
+sealed class LoginState(previousState: UiState?, isFirstScreen: Boolean) : UiState(previousState, isFirstScreen) {
+    data class Entering(val email: String, val password: String,private val lastScreen: UiState?): LoginState(lastScreen, false) {
         fun toLoading() = Loading(this)
         companion object {
             fun init(previousState: UiState?): Entering {
@@ -12,13 +12,13 @@ sealed class LoginState(previousState: UiState?) : UiState(previousState, false)
         }
     }
 
-    data class Loading(val details: Entering): LoginState(null) {
+    data class Loading(val details: Entering): LoginState(null, false) {
         fun toError(msg: String) = Error(msg, details)
     }
 
-    data class Error(val message: String, val details: Entering): LoginState(details) {
+    data class Error(val message: String, val details: Entering): LoginState(details, false) {
         fun toEntering() = details
     }
 
-    data class LoggedIn(val name: String, val token: String, private val lastScreen: UiState?): LoginState(lastScreen)
+    data class LoggedIn(val name: String, val token: String): LoginState(null, true)
 }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/register/Reducer.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/register/Reducer.kt
@@ -52,7 +52,7 @@ fun reduceRegisterAction(action: RegisterAction, state: AppState): AppEffect {
             emptyList()
         )
         is RegisterAction.Accepted -> AppEffect(
-            state.copy(uiState = RegisterState.Registered(action.name, action.token, (state.uiState as RegisterState.Loading).details)),
+            state.copy(uiState = RegisterState.Registered(action.name, action.token)),
             emptyList()
         )
     }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/register/Reducer.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/register/Reducer.kt
@@ -52,7 +52,7 @@ fun reduceRegisterAction(action: RegisterAction, state: AppState): AppEffect {
             emptyList()
         )
         is RegisterAction.Accepted -> AppEffect(
-            state.copy(uiState = RegisterState.Registered(action.name, action.token)),
+            state.copy(uiState = RegisterState.Registered(action.name, action.token, (state.uiState as RegisterState.Loading).details)),
             emptyList()
         )
     }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/register/State.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/register/State.kt
@@ -2,23 +2,30 @@ package app.emmabritton.cibusana.system.register
 
 import app.emmabritton.cibusana.system.UiState
 
-sealed class RegisterState: UiState {
-    data class Entering(val email: String, val password: String, val name: String): RegisterState() {
+sealed class RegisterState(previousState: UiState?) : UiState(previousState, false) {
+    data class Entering(
+        val email: String,
+        val password: String,
+        val name: String,
+        private val lastScreen: UiState?
+    ) : RegisterState(lastScreen) {
         fun toLoading() = Loading(this)
+
         companion object {
-            fun init(): Entering {
-                return Entering("", "", "")
+            fun init(previousState: UiState?): Entering {
+                return Entering("", "", "", previousState)
             }
         }
     }
 
-    data class Loading(val details: Entering): RegisterState() {
+    data class Loading(val details: Entering) : RegisterState(null) {
         fun toError(msg: String) = Error(msg, details)
     }
 
-    data class Error(val message: String, val details: Entering): RegisterState() {
+    data class Error(val message: String, val details: Entering) : RegisterState(details) {
         fun toEntering() = details
     }
 
-    data class Registered(val name: String, val token: String): RegisterState()
+    data class Registered(val name: String, val token: String, private val lastScreen: UiState?) :
+        RegisterState(lastScreen)
 }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/register/State.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/register/State.kt
@@ -2,13 +2,13 @@ package app.emmabritton.cibusana.system.register
 
 import app.emmabritton.cibusana.system.UiState
 
-sealed class RegisterState(previousState: UiState?) : UiState(previousState, false) {
+sealed class RegisterState(previousState: UiState?, isFirstScreen: Boolean) : UiState(previousState, isFirstScreen) {
     data class Entering(
         val email: String,
         val password: String,
         val name: String,
         private val lastScreen: UiState?
-    ) : RegisterState(lastScreen) {
+    ) : RegisterState(lastScreen, false) {
         fun toLoading() = Loading(this)
 
         companion object {
@@ -18,14 +18,14 @@ sealed class RegisterState(previousState: UiState?) : UiState(previousState, fal
         }
     }
 
-    data class Loading(val details: Entering) : RegisterState(null) {
+    data class Loading(val details: Entering) : RegisterState(null, false) {
         fun toError(msg: String) = Error(msg, details)
     }
 
-    data class Error(val message: String, val details: Entering) : RegisterState(details) {
+    data class Error(val message: String, val details: Entering) : RegisterState(details, false) {
         fun toEntering() = details
     }
 
-    data class Registered(val name: String, val token: String, private val lastScreen: UiState?) :
-        RegisterState(lastScreen)
+    data class Registered(val name: String, val token: String) :
+        RegisterState(null, true)
 }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/welcome/Reducer.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/welcome/Reducer.kt
@@ -7,7 +7,7 @@ import app.emmabritton.cibusana.system.register.RegisterState
 
 fun reduceWelcomeAction(action: WelcomeAction, state: AppState): AppEffect {
     return when (action) {
-        WelcomeAction.UserPressedLogin -> AppEffect(state.copy(uiState = LoginState.Entering.init()), emptyList())
-        WelcomeAction.UserPressedRegister -> AppEffect(state.copy(uiState = RegisterState.Entering.init()), emptyList())
+        WelcomeAction.UserPressedLogin -> AppEffect(state.copy(uiState = LoginState.Entering.init(state.uiState)), emptyList())
+        WelcomeAction.UserPressedRegister -> AppEffect(state.copy(uiState = RegisterState.Entering.init(state.uiState)), emptyList())
     }
 }

--- a/app/app/src/main/java/app/emmabritton/cibusana/system/welcome/State.kt
+++ b/app/app/src/main/java/app/emmabritton/cibusana/system/welcome/State.kt
@@ -2,4 +2,4 @@ package app.emmabritton.cibusana.system.welcome
 
 import app.emmabritton.cibusana.system.UiState
 
-object WelcomeState : UiState
+object WelcomeState : UiState(null, true)


### PR DESCRIPTION
Possible implementation to enable back button and returning to previous screens.

It works by storing the last valid screen state in the current one and then when back is pressed restoring the old state.

This allows screens to break the stack (for example when coming from a splash screen) or to invent a stack (for example when coming from a deep link). 

If there is no previous screen then pressing back does nothing, unless a flag is set to indicate that the app should close (this should only be set for the first screen of the app (e.g. a home page), or after login).

Normally apps allow users to go back at any point, but that won't work with the current implementation as otherwise you could go back while logging in and the login command would deliver login actions to the welcome screen so I have disabled going back on the loading screens, but they store the entering screen state and could pass it to error/success screens.

To fix the issue above I think I need to add the ability to cancel commands and ignore any actions from them. (But, with the login example, the command would have still saved the users token, etc into the app and so the user would be on the welcome screen and logged in so maybe global actions (loggedin, loggedout, etc) would be better)